### PR TITLE
use a different regex to get the chat name

### DIFF
--- a/gptchats/main-loader.js
+++ b/gptchats/main-loader.js
@@ -6,11 +6,12 @@ import("/gptchats/importer.js").then((myModule)=>
   loadChat("/gptchats/"+getPageName(location.href)
     +"/chat.json","#chatgpt-conversation")})
 
-//https://stackoverflow.com/questions/30863164/extract-urls-directory-from-path-without-file-name-such-as-index-html
 function getPageName(url)
   {debugger;
-  var match=url.match
-    (/^(.*)\/([^.]+(\.([^?#]+))+)(\?[^#]*)?(#.*)?$/);
+  // (anything) (slash) (single path component) (slash) (optional 'index.html') (optional query and fragment)
+  // this matches /gptchats/spam/ and /gptchats/spam/index.html (plus an optional bit after ? or #)
+  // /gptchats/spam is redirected to /gptchats/spam/
+  var match=url.match(/^.*\/([^/]+)\/(index\.html)?([?#].*)?/);
   if(match!==null)
     {const{[1]:dir,[2]:file,[4]:ext}=match;url=dir}
   return url.substring(url.lastIndexOf("/")+1)}


### PR DESCRIPTION
the old one only worked when the url has index.html because it expects a file name with a dot as the last path component
when the last path component doesn't have a dot, like 'https://fireydeath4.github.io/gptchats/spam/', for example, it instead matches the dot against the dot in the domain, making a "file name" of 'fireydeath4.github.io/gptchats/spam/' and a "directory name" of 'https:/' (with one slash)
(which wouldn't have happened if the [^?#] was [^\/?#], like the original, stopping the "file name" from having slashes)
then the part after the last slash is the returned "page name" of '' (empty string)

learn regex please <3 <3 <3 <3 <3 <3